### PR TITLE
Fixed navigator reset on input mode change

### DIFF
--- a/addon/globalPlugins/ime_expressive.py
+++ b/addon/globalPlugins/ime_expressive.py
@@ -292,7 +292,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 
 	def clear_ime(self):
 		global lastCandidate
-		if api.getNavigatorObject().windowText=='Microsoft Text Input Application' and (not api.getNavigatorObject().isFocusable): self.setNavigatorObject(api.getFocusObject())
+		if api.getNavigatorObject() and api.getNavigatorObject().windowText=='Microsoft Text Input Application' and (not api.getNavigatorObject().isFocusable): self.setNavigatorObject(api.getFocusObject())
 		lastCandidate=''
 		self.selectedCandidate=''
 		self.selectedIndex=0

--- a/addon/globalPlugins/ime_expressive.py
+++ b/addon/globalPlugins/ime_expressive.py
@@ -292,7 +292,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 
 	def clear_ime(self):
 		global lastCandidate
-		self.setNavigatorObject(api.getFocusObject())
+		if api.getNavigatorObject().windowText=='Microsoft Text Input Application' and (not api.getNavigatorObject().isFocusable): self.setNavigatorObject(api.getFocusObject())
 		lastCandidate=''
 		self.selectedCandidate=''
 		self.selectedIndex=0


### PR DESCRIPTION
When an addon reports a change in input mode, it resets the navigator. The solution is to check the current properties of the navigator. Notice that when the input method candidate list disappears, although the navigator is still in the input method candidate list, the isFocusable property of the list item is FALSE. Therefore, the navigator only needs to be reset when it is in the input method candidate list and the isFocusable property is FALSE.