### PR TITLE
• Fix errors caused by rapidly pressing the spacebar in Microsoft Input Method

### DIFF
--- a/addon/globalPlugins/ime_expressive.py
+++ b/addon/globalPlugins/ime_expressive.py
@@ -147,6 +147,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 	candidateList=[]
 	selectedIndex=0
 	def handleInputCandidateListUpdate(self,candidatesString,selectionIndex,inputMethod):
+		if inputMethod == 'ms' and self.inputEnd: return
 		global pt,lastCandidate
 		if candidatesString:
 			ct=time.time()
@@ -228,6 +229,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 
 	isSkip=False
 	def handleInputCompositionStart(self,compositionString,selectionStart,selectionEnd,isReading):
+		self.inputEnd = False
 		if self.isSkip:
 			self.isSkip=False
 			return
@@ -290,7 +292,9 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 					charInfo.move(textInfos.UNIT_CHARACTER,1)
 					api.setReviewPosition(charInfo)
 
+	inputEnd = True
 	def clear_ime(self):
+		self.inputEnd = True
 		global lastCandidate
 		if api.getNavigatorObject() and api.getNavigatorObject().windowText=='Microsoft Text Input Application' and (not api.getNavigatorObject().isFocusable): self.setNavigatorObject(api.getFocusObject())
 		lastCandidate=''


### PR DESCRIPTION
When using Microsoft IME to input Chinese characters, rapidly pressing the spacebar after the candidate list updates may cause the edit box to become unresponsive to cursor movement events.

This issue occurs because the addon, after unbinding the gestures event from the edit box, inadvertently rebinds the gestures event due to a delayed refresh of the candidate list.

Therefore, an inputEnd event has been added to determine the input state.

Oh my god, I swear Microsoft IME is so difficult to work with.